### PR TITLE
User can empty a cart that has items

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -13,4 +13,10 @@ class CartsController < ApplicationController
 
   def show
   end
+
+  def destroy
+    reset_session
+    flash[:message] = "Your cart is now empty, anti-capitalist!"
+    redirect_to cart_path
+  end
 end

--- a/spec/features/carts/show_spec.rb
+++ b/spec/features/carts/show_spec.rb
@@ -42,6 +42,18 @@ RSpec.describe "cart show page", type: :feature do
 
       expect(page).to have_content("Grand Total: $#{ 2 * @item_1.price +  @item_2.price }")
     end
+
+    it "I click on Empty Cart, all items are removed" do
+      visit cart_path
+      click_button "Empty Cart"
+
+      expect(current_path).to eq(cart_path)
+      expect(page).to have_content("Your cart is now empty, anti-capitalist!")
+
+      expect(page).to have_content("Cart: 0")
+      expect(page).to_not have_link(@item_1.name)
+      expect(page).to_not have_link(@item_2.name)
+    end
   end
 
   context "as a user" do
@@ -87,6 +99,19 @@ RSpec.describe "cart show page", type: :feature do
       end
 
       expect(page).to have_content("Grand Total: $#{ 2 * @item_1.price +  @item_2.price }")
+    end
+
+    it "I click on Empty Cart, all items are removed" do
+      visit cart_path
+      click_button "Empty Cart"
+
+      expect(current_path).to eq(cart_path)
+      expect(page).to have_content("Your cart is now empty, anti-capitalist!")
+
+      expect(page).to have_content("Cart: 0")
+    save_and_open_page
+      expect(page).to_not have_link(@item_1.name)
+      expect(page).to_not have_link(@item_2.name)
     end
   end
 end

--- a/spec/features/carts/show_spec.rb
+++ b/spec/features/carts/show_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe "cart show page", type: :feature do
       expect(page).to have_content("Your cart is now empty, anti-capitalist!")
 
       expect(page).to have_content("Cart: 0")
-    save_and_open_page
+
       expect(page).to_not have_link(@item_1.name)
       expect(page).to_not have_link(@item_2.name)
     end

--- a/spec/features/carts/show_spec.rb
+++ b/spec/features/carts/show_spec.rb
@@ -109,7 +109,6 @@ RSpec.describe "cart show page", type: :feature do
       expect(page).to have_content("Your cart is now empty, anti-capitalist!")
 
       expect(page).to have_content("Cart: 0")
-
       expect(page).to_not have_link(@item_1.name)
       expect(page).to_not have_link(@item_2.name)
     end


### PR DESCRIPTION
Completes User Story 23 (#60 )

Feature and model tests at 100%

A registered user or a visitor can empty their cart, the cart count goes to zero and clear cart session.

Please check for thorough edge-case testing. Thank you.