### PR TITLE
User Profile (show & edit) - User Stories 17/18/19

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,15 +23,10 @@ class UsersController < ApplicationController
   end
 
   def update
-    # to-do: use update_attributes to combine all these
-    current_user.update_attribute(:name, params[:name])
-    current_user.update_attribute(:address, params[:address])
-    current_user.update_attribute(:city, params[:city])
-    current_user.update_attribute(:state, params[:state])
-    current_user.update_attribute(:zip, params[:zip])
+    current_user.update_attributes(name: params[:name], address: params[:address], city: params[:city], state: params[:state], zip: params[:zip])
 
     if User.find_by(email: params[:email].downcase) && current_user.email != params[:email].downcase
-      flash[:error] = "Email already taken"
+      flash[:error] = "That email address is already in use"
       redirect_to profile_edit_path
     else
       current_user.update_attribute(:email, params[:email])
@@ -43,8 +38,5 @@ class UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(:name, :email, :address, :city, :state, :zip, :password, :password_confirmation)
-  end
-
-  def show
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,6 +23,7 @@ class UsersController < ApplicationController
   end
 
   def update
+    current_user.update(current_user_params)
     redirect_to profile_path
   end
 
@@ -30,6 +31,10 @@ class UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(:name, :email, :address, :city, :state, :zip, :password, :password_confirmation)
+  end
+
+  def current_user_params
+    params.permit(:name, :email, :address, :city, :state, :zip, :password, :password_confirmation)
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,6 +22,10 @@ class UsersController < ApplicationController
   def edit
   end
 
+  def update
+    redirect_to profile_path
+  end
+
   private
 
   def user_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,6 +29,7 @@ class UsersController < ApplicationController
       return
     else
       if current_user.update(update_params.to_h)
+        flash[:notice] = "Your profile has been updated"
         redirect_to profile_path
       else
         flash[:error] = current_user.errors.full_messages.join(". ")

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,17 +23,17 @@ class UsersController < ApplicationController
   end
 
   def update
-    user = User.find(session[:user_id])
-    if User.find_by(email: params[:email].downcase) && user.email != params[:email].downcase
+    if current_user.email != params[:email].downcase && User.find_by(email: params[:email].downcase)
       flash[:error] = "That email address is already in use"
       redirect_to profile_edit_path
       return
     else
-      if user.update(update_params.to_h)
+      if current_user.update(update_params.to_h)
         redirect_to profile_path
       else
-        flash[:error] = user.errors.full_messages.join(". ")
+        flash[:error] = current_user.errors.full_messages.join(". ")
         redirect_to profile_edit_path
+        return
       end
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,18 +23,26 @@ class UsersController < ApplicationController
   end
 
   def update
-    current_user.update(current_user_params)
-    redirect_to profile_path
+    # to-do: use update_attributes to combine all these
+    current_user.update_attribute(:name, params[:name])
+    current_user.update_attribute(:address, params[:address])
+    current_user.update_attribute(:city, params[:city])
+    current_user.update_attribute(:state, params[:state])
+    current_user.update_attribute(:zip, params[:zip])
+
+    if User.find_by(email: params[:email].downcase) && current_user.email != params[:email].downcase
+      flash[:error] = "Email already taken"
+      redirect_to profile_edit_path
+    else
+      current_user.update_attribute(:email, params[:email])
+      redirect_to profile_path
+    end
   end
 
   private
 
   def user_params
     params.require(:user).permit(:name, :email, :address, :city, :state, :zip, :password, :password_confirmation)
-  end
-
-  def current_user_params
-    params.permit(:name, :email, :address, :city, :state, :zip, :password, :password_confirmation)
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,6 +28,7 @@ class UsersController < ApplicationController
     if User.find_by(email: params[:email].downcase) && current_user.email != params[:email].downcase
       flash[:error] = "That email address is already in use"
       redirect_to profile_edit_path
+      return
     else
       current_user.update_attribute(:email, params[:email])
       redirect_to profile_path

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,6 +19,9 @@ class UsersController < ApplicationController
     end
   end
 
+  def edit
+  end
+
   private
 
   def user_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ApplicationRecord
   enum role: ['user', 'merchant', 'admin']
 
   validates :email, uniqueness: true, presence: true
-  validates_presence_of :password, require: true
+  validates_presence_of :password_digest
 
   has_secure_password
 end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="login-form">
+<div id="profile-edit-form">
   <%= form_tag profile_path, method: :patch do %>
     <%= label_tag :name %>
     <%= text_field_tag :name, current_user.name, required: true %>
@@ -8,6 +8,9 @@
     <br>
     <%= label_tag :password %>
     <%= password_field_tag :password, nil %>
+    <br>
+    <%= label_tag :password_confirmation %>
+    <%= password_field_tag :password_confirmation, nil %>
     <br>
     <%= label_tag :address %>
     <%= text_field_tag :address, current_user.address, required: true %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,26 @@
+<div class="login-form">
+  <%= form_tag profile_path, method: :patch do %>
+    <%= label_tag :name %>
+    <%= text_field_tag :name, current_user.name, required: true %>
+    <br>
+    <%= label_tag :email %>
+    <%= email_field_tag :email, current_user.email, required: true %>
+    <br>
+    <%= label_tag :password %>
+    <%= password_field_tag :password, nil %>
+    <br>
+    <%= label_tag :address %>
+    <%= text_field_tag :address, current_user.address, required: true %>
+    <br>
+    <%= label_tag :city %>
+    <%= text_field_tag :city, current_user.city, required: true %>
+    <br>
+    <%= label_tag :state %>
+    <%= text_field_tag :state, current_user.state, required: true %>
+    <br>
+    <%= label_tag :zip %>
+    <%= text_field_tag :zip, current_user.zip, required: true %>
+    <br>
+    <%= submit_tag 'Submit Changes' %>
+  <% end %>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,5 @@
+<h1><%= current_user.name %></h1>
+<p><%= current_user.email %></p>
+<p><%= current_user.address %></p>
+<p><%= current_user.city %>, <%= current_user.state %></p>
+<p><%= current_user.zip %></p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,3 +3,5 @@
 <p><%= current_user.address %></p>
 <p><%= current_user.city %>, <%= current_user.state %></p>
 <p><%= current_user.zip %></p>
+
+<%= link_to "Edit My Profile or Password", profile_edit_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   get '/logout', to: "sessions#destroy"
 
   get '/profile', to: "users#show"
+  patch '/profile', to: "users#update"
   get '/profile/edit', to: "users#edit"
   get '/register', to: "users#new"
   get '/dashboard', to: "merchants#show"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   get '/logout', to: "sessions#destroy"
 
   get '/profile', to: "users#show"
+  get '/profile/edit', to: "users#edit"
   get '/register', to: "users#new"
   get '/dashboard', to: "merchants#show"
   get '/merchants', to: "merchants#index"

--- a/spec/features/users/profile_edit_spec.rb
+++ b/spec/features/users/profile_edit_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe "profile edit page" do
       expect(current_path).to eq(profile_edit_path)
 
       expect(page).to_not have_content(new_email)
-      expect(page).to have_content("Email already taken")
+      expect(page).to have_content("That email address is already in use")
       expect(@user.password).to eq(@password)
     end
   end

--- a/spec/features/users/profile_edit_spec.rb
+++ b/spec/features/users/profile_edit_spec.rb
@@ -19,8 +19,13 @@ RSpec.describe "profile edit page" do
                            zip:      @zip
                           )
 
-      allow_any_instance_of(ApplicationController).to receive(:current_user)
-        .and_return(@user)
+      visit login_path
+
+      within('.login-form') do
+        fill_in "Email", with: @email
+        fill_in "Password", with: @password
+        click_on "Login"
+      end
     end
 
     it "shows a form to edit my profile data" do
@@ -56,19 +61,6 @@ RSpec.describe "profile edit page" do
 
       expect(page).to have_content(new_name)
       expect(page).to_not have_content(@name)
-      expect(@user.password).to eq(@password)
-    end
-
-    it "I can edit my email" do
-      visit profile_edit_path
-
-      new_email = "Bob@Bob.com"
-
-      fill_in :email, with: new_email
-      click_button "Submit Changes"
-
-      expect(page).to have_content(new_email)
-      expect(page).to_not have_content(@email)
       expect(@user.password).to eq(@password)
     end
 
@@ -121,6 +113,35 @@ RSpec.describe "profile edit page" do
 
       expect(page).to have_content(new_zip)
       expect(page).to_not have_content(@zip)
+      expect(@user.password).to eq(@password)
+    end
+
+    it "I can change my email to an unused email address" do
+      visit profile_edit_path
+
+      new_email = "Bob@Bobbin.com"
+
+      fill_in :email, with: new_email
+      click_button "Submit Changes"
+
+      expect(page).to have_content(new_email.downcase)
+      expect(page).to_not have_content(@email)
+      expect(@user.password).to eq(@password)
+    end
+
+    it "I cannot change my email to an already used email address" do
+      new_email = "Bob@Bobbin.com"
+      create(:user, email: new_email)
+
+      visit profile_edit_path
+
+      fill_in :email, with: new_email
+      click_button "Submit Changes"
+
+      expect(current_path).to eq(profile_edit_path)
+
+      expect(page).to_not have_content(new_email)
+      expect(page).to have_content("Email already taken")
       expect(@user.password).to eq(@password)
     end
   end

--- a/spec/features/users/profile_edit_spec.rb
+++ b/spec/features/users/profile_edit_spec.rb
@@ -116,9 +116,9 @@ RSpec.describe "profile edit page" do
       expect(page).to_not have_content(@zip)
 
       expect(page).to have_content("Your profile has been updated")
-      updated_user = User.find(@user.id)
-      expect(updated_user.zip).to eq(new_zip)
-      expect(updated_user.password_digest).to eq(original_pw_digest)
+      @user.reload
+      expect(@user.zip).to eq(new_zip)
+      expect(@user.password_digest).to eq(original_pw_digest)
     end
 
     it "I can change my email to an unused email address" do
@@ -161,8 +161,8 @@ RSpec.describe "profile edit page" do
       click_button "Submit Changes"
 
       expect(page).to have_content("Your profile has been updated")
-      updated_user = User.find(@user.id)
-      expect(updated_user.password_digest).to_not eq(original_pw_digest)
+      @user.reload
+      expect(@user.password_digest).to_not eq(original_pw_digest)
     end
 
     it "my password doesn't change when confirmation doesn't match" do
@@ -179,8 +179,8 @@ RSpec.describe "profile edit page" do
       expect(page).to have_content("Password confirmation doesn't match Password")
       expect(current_path).to eq(profile_edit_path)
 
-      updated_user = User.find(@user.id)
-      expect(updated_user.password_digest).to eq(original_pw_digest)
+      @user.reload
+      expect(@user.password_digest).to eq(original_pw_digest)
     end
   end
 end

--- a/spec/features/users/profile_edit_spec.rb
+++ b/spec/features/users/profile_edit_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe "profile edit page" do
       fill_in :name, with: new_name
       click_button "Submit Changes"
 
+      expect(page).to have_content("Your profile has been updated")
       expect(page).to have_content(new_name)
       expect(page).to_not have_content(@name)
     end
@@ -71,6 +72,7 @@ RSpec.describe "profile edit page" do
       fill_in :address, with: new_address
       click_button "Submit Changes"
 
+      expect(page).to have_content("Your profile has been updated")
       expect(page).to have_content(new_address)
       expect(page).to_not have_content(@address)
     end
@@ -83,6 +85,7 @@ RSpec.describe "profile edit page" do
       fill_in :city, with: new_city
       click_button "Submit Changes"
 
+      expect(page).to have_content("Your profile has been updated")
       expect(page).to have_content(new_city)
       expect(page).to_not have_content(@city)
     end
@@ -95,6 +98,7 @@ RSpec.describe "profile edit page" do
       fill_in :state, with: new_state
       click_button "Submit Changes"
 
+      expect(page).to have_content("Your profile has been updated")
       expect(page).to have_content(new_state)
       expect(page).to_not have_content(@state)
     end
@@ -111,6 +115,7 @@ RSpec.describe "profile edit page" do
       expect(page).to have_content(new_zip)
       expect(page).to_not have_content(@zip)
 
+      expect(page).to have_content("Your profile has been updated")
       updated_user = User.find(@user.id)
       expect(updated_user.zip).to eq(new_zip)
       expect(updated_user.password_digest).to eq(original_pw_digest)
@@ -124,6 +129,7 @@ RSpec.describe "profile edit page" do
       fill_in :email, with: new_email
       click_button "Submit Changes"
 
+      expect(page).to have_content("Your profile has been updated")
       expect(page).to have_content(new_email.downcase)
       expect(page).to_not have_content(@email)
     end
@@ -139,6 +145,7 @@ RSpec.describe "profile edit page" do
 
       expect(current_path).to eq(profile_edit_path)
 
+      expect(page).to_not have_content("Your profile has been updated")
       expect(page).to_not have_content(new_email)
       expect(page).to have_content("That email address is already in use")
     end
@@ -153,6 +160,7 @@ RSpec.describe "profile edit page" do
       fill_in :password_confirmation, with: new_password
       click_button "Submit Changes"
 
+      expect(page).to have_content("Your profile has been updated")
       updated_user = User.find(@user.id)
       expect(updated_user.password_digest).to_not eq(original_pw_digest)
     end
@@ -167,6 +175,7 @@ RSpec.describe "profile edit page" do
       fill_in :password_confirmation, with: new_password.upcase
       click_button "Submit Changes"
 
+      expect(page).to_not have_content("Your profile has been updated")
       expect(page).to have_content("Password confirmation doesn't match Password")
       expect(current_path).to eq(profile_edit_path)
 

--- a/spec/features/users/profile_edit_spec.rb
+++ b/spec/features/users/profile_edit_spec.rb
@@ -3,13 +3,20 @@ require 'rails_helper'
 RSpec.describe "profile edit page" do
   context "as a user" do
     before(:each) do
-      @user = User.create!(email:    "abc@def.com",
-                           password: "pw123",
-                           name:     "Abc Def",
-                           address:  "123 Abc St",
-                           city:     "NYC",
-                           state:    "NY",
-                           zip:      "12345"
+      @email = "abc@def.com"
+      @password = "pw123"
+      @name = "Abc Def"
+      @address = "123 Abc St"
+      @city = "New York City"
+      @state = "NY"
+      @zip = "12345"
+      @user = User.create!(email:    @email,
+                           password: @password,
+                           name:     @name,
+                           address:  @address,
+                           city:     @city,
+                           state:    @state,
+                           zip:      @zip
                           )
 
       allow_any_instance_of(ApplicationController).to receive(:current_user)
@@ -22,6 +29,7 @@ RSpec.describe "profile edit page" do
       expect(page).to have_field(:name)
       expect(page).to have_field(:email)
       expect(page).to have_field(:password)
+      expect(page).to have_field(:password_confirmation)
       expect(page).to have_field(:address)
       expect(page).to have_field(:city)
       expect(page).to have_field(:state)
@@ -36,6 +44,84 @@ RSpec.describe "profile edit page" do
       expect(page).to have_content(@user.address)
       expect(page).to have_content("#{@user.city}, #{@user.state}")
       expect(page).to have_content(@user.zip)
+    end
+
+    it "I can edit my name" do
+      visit profile_edit_path
+
+      new_name = "Bob"
+
+      fill_in :name, with: new_name
+      click_button "Submit Changes"
+
+      expect(page).to have_content(new_name)
+      expect(page).to_not have_content(@name)
+      expect(@user.password).to eq(@password)
+    end
+
+    it "I can edit my email" do
+      visit profile_edit_path
+
+      new_email = "Bob@Bob.com"
+
+      fill_in :email, with: new_email
+      click_button "Submit Changes"
+
+      expect(page).to have_content(new_email)
+      expect(page).to_not have_content(@email)
+      expect(@user.password).to eq(@password)
+    end
+
+    it "I can edit my address" do
+      visit profile_edit_path
+
+      new_address = "7264 Blah St"
+
+      fill_in :address, with: new_address
+      click_button "Submit Changes"
+
+      expect(page).to have_content(new_address)
+      expect(page).to_not have_content(@address)
+      expect(@user.password).to eq(@password)
+    end
+
+    it "I can edit my city" do
+      visit profile_edit_path
+
+      new_city = "New Orleans"
+
+      fill_in :city, with: new_city
+      click_button "Submit Changes"
+
+      expect(page).to have_content(new_city)
+      expect(page).to_not have_content(@city)
+      expect(@user.password).to eq(@password)
+    end
+
+    it "I can edit my state" do
+      visit profile_edit_path
+
+      new_state = "LA"
+
+      fill_in :state, with: new_state
+      click_button "Submit Changes"
+
+      expect(page).to have_content(new_state)
+      expect(page).to_not have_content(@state)
+      expect(@user.password).to eq(@password)
+    end
+
+    it "I can edit my zip" do
+      visit profile_edit_path
+
+      new_zip = "83649"
+
+      fill_in :zip, with: new_zip
+      click_button "Submit Changes"
+
+      expect(page).to have_content(new_zip)
+      expect(page).to_not have_content(@zip)
+      expect(@user.password).to eq(@password)
     end
   end
 end

--- a/spec/features/users/profile_edit_spec.rb
+++ b/spec/features/users/profile_edit_spec.rb
@@ -144,5 +144,29 @@ RSpec.describe "profile edit page" do
       expect(page).to have_content("That email address is already in use")
       expect(@user.password).to eq(@password)
     end
+
+    it "I can edit my password (when confirmation matches)" do
+      visit profile_edit_path
+
+      new_password = "newPassword"
+
+      fill_in :password, with: new_password
+      fill_in :password_confirmation, with: new_password
+      click_button "Submit Changes"
+
+      expect(@user.password).to eq(new_password)
+    end
+
+    it "my password doesn't change when confirmation doesn't match" do
+      visit profile_edit_path
+
+      new_password = "newPassword"
+
+      fill_in :password, with: new_password.downcase
+      fill_in :password_confirmation, with: new_password.upcase
+      click_button "Submit Changes"
+
+      expect(@user.password).to eq(@password)
+    end
   end
 end

--- a/spec/features/users/profile_edit_spec.rb
+++ b/spec/features/users/profile_edit_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe "profile edit page" do
+  context "as a user" do
+    before(:each) do
+      @user = User.create!(email:    "abc@def.com",
+                           password: "pw123",
+                           name:     "Abc Def",
+                           address:  "123 Abc St",
+                           city:     "NYC",
+                           state:    "NY",
+                           zip:      "12345"
+                          )
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user)
+        .and_return(@user)
+    end
+
+    it "shows a form to edit my profile data" do
+      visit profile_edit_path
+
+      expect(page).to have_field(:name)
+      expect(page).to have_field(:email)
+      expect(page).to have_field(:password)
+      expect(page).to have_field(:address)
+      expect(page).to have_field(:city)
+      expect(page).to have_field(:state)
+      expect(page).to have_field(:zip)
+
+      click_button "Submit Changes"
+
+      expect(current_path).to eq(profile_path)
+
+      expect(page).to have_content(@user.name)
+      expect(page).to have_content(@user.email)
+      expect(page).to have_content(@user.address)
+      expect(page).to have_content("#{@user.city}, #{@user.state}")
+      expect(page).to have_content(@user.zip)
+    end
+  end
+end

--- a/spec/features/users/profile_edit_spec.rb
+++ b/spec/features/users/profile_edit_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe "profile edit page" do
 
       expect(page).to have_content(new_name)
       expect(page).to_not have_content(@name)
-      expect(@user.password).to eq(@password)
     end
 
     it "I can edit my address" do
@@ -74,7 +73,6 @@ RSpec.describe "profile edit page" do
 
       expect(page).to have_content(new_address)
       expect(page).to_not have_content(@address)
-      expect(@user.password).to eq(@password)
     end
 
     it "I can edit my city" do
@@ -87,7 +85,6 @@ RSpec.describe "profile edit page" do
 
       expect(page).to have_content(new_city)
       expect(page).to_not have_content(@city)
-      expect(@user.password).to eq(@password)
     end
 
     it "I can edit my state" do
@@ -100,20 +97,23 @@ RSpec.describe "profile edit page" do
 
       expect(page).to have_content(new_state)
       expect(page).to_not have_content(@state)
-      expect(@user.password).to eq(@password)
     end
 
-    it "I can edit my zip" do
+    it "I can edit my zip (and my password is unchanged)" do
       visit profile_edit_path
 
       new_zip = "83649"
+      original_pw_digest = @user.password_digest
 
       fill_in :zip, with: new_zip
       click_button "Submit Changes"
 
       expect(page).to have_content(new_zip)
       expect(page).to_not have_content(@zip)
-      expect(@user.password).to eq(@password)
+
+      updated_user = User.find(@user.id)
+      expect(updated_user.zip).to eq(new_zip)
+      expect(updated_user.password_digest).to eq(original_pw_digest)
     end
 
     it "I can change my email to an unused email address" do
@@ -126,7 +126,6 @@ RSpec.describe "profile edit page" do
 
       expect(page).to have_content(new_email.downcase)
       expect(page).to_not have_content(@email)
-      expect(@user.password).to eq(@password)
     end
 
     it "I cannot change my email to an already used email address" do
@@ -142,31 +141,37 @@ RSpec.describe "profile edit page" do
 
       expect(page).to_not have_content(new_email)
       expect(page).to have_content("That email address is already in use")
-      expect(@user.password).to eq(@password)
     end
 
     it "I can edit my password (when confirmation matches)" do
       visit profile_edit_path
 
       new_password = "newPassword"
+      original_pw_digest = @user.password_digest
 
       fill_in :password, with: new_password
       fill_in :password_confirmation, with: new_password
       click_button "Submit Changes"
 
-      expect(@user.password).to eq(new_password)
+      updated_user = User.find(@user.id)
+      expect(updated_user.password_digest).to_not eq(original_pw_digest)
     end
 
     it "my password doesn't change when confirmation doesn't match" do
       visit profile_edit_path
 
       new_password = "newPassword"
+      original_pw_digest = @user.password_digest
 
       fill_in :password, with: new_password.downcase
       fill_in :password_confirmation, with: new_password.upcase
       click_button "Submit Changes"
 
-      expect(@user.password).to eq(@password)
+      expect(page).to have_content("Password confirmation doesn't match Password")
+      expect(current_path).to eq(profile_edit_path)
+
+      updated_user = User.find(@user.id)
+      expect(updated_user.password_digest).to eq(original_pw_digest)
     end
   end
 end

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe "profile page" do
+  context "as a user" do
+    before(:each) do
+      @user = User.create!(email:    "abc@def.com",
+                           password: "pw123",
+                           name:     "Abc Def",
+                           address:  "123 Abc St",
+                           city:     "NYC",
+                           state:    "NY",
+                           zip:      "12345"
+                          )
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user)
+        .and_return(@user)
+    end
+
+    it "shows my profile data" do
+      visit profile_path
+
+      expect(page).to have_content(@user.name)
+      expect(page).to have_content(@user.email)
+      expect(page).to have_content(@user.address)
+      expect(page).to have_content("#{@user.city}, #{@user.state}")
+      expect(page).to have_content(@user.zip)
+    end
+
+    xit "has a link to edit my profile data" do
+      visit profile_path
+
+      click_link "Edit My Profile or Password"
+
+      expect(current_path).to eq("/profile/edit")
+    end
+  end
+end

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -26,12 +26,12 @@ RSpec.describe "profile page" do
       expect(page).to have_content(@user.zip)
     end
 
-    xit "has a link to edit my profile data" do
+    it "has a link to edit my profile data" do
       visit profile_path
 
       click_link "Edit My Profile or Password"
 
-      expect(current_path).to eq("/profile/edit")
+      expect(current_path).to eq(profile_edit_path)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe User, type: :model do
     it {should validate_presence_of :zip}
 
     it {should validate_presence_of :email}
-    it {should validate_presence_of :password}
+    it {should validate_presence_of :password_digest}
   end
 
   describe 'relationships' do


### PR DESCRIPTION
Closes User Stories 17 (#66), 18 (#65), 19 (#64):
 - Adds user show page (profile with data for the current user)
 - Adds form to edit the user's own data
 - Allows for changing of all data, including password (which must match the password confirmation field), email (which must not match a different existing user).
 - The form autofills with the user's existing data
 - If the password field is left blank, the password is not changed from their existing one
Also:
 - Changed `validates_presence_of :password, require: true` to `validates_presence_of :password_digest` in User model

Feature tests(%) - 100
Model tests(%) - 100
Commented Hard to Understand Areas? N/A
Other notes: 
 - The tests were being stupid for making sure the data actually updated. I set up `user_1 = User.create(name: ...etc..)`. I used the form to edit the user’s data, say `new_address`. Then I tried `expect(user_1.address).to eq(new_address)` but it kept failing. However, if I looked up `updated_user = User.find(user_1.id)` and did `expect(updated_user.address).to eq(new_address)`, it worked! No idea why, but it is working fine in production and tests fine once I make this change. Very annoying. I noticed this because in Pry it all looked perfect other than the unique object identifier (you know, the big long Ruby object number in <>, not the id in the actual user table).