### PR TITLE
Format prices

### DIFF
--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -4,13 +4,13 @@
       <%= link_to item.name, item_path(item) %>
       <%= image_tag item.image || @default_image, alt: "image of #{item.name}" %>
       <p><%= item.user.name %></p>
-      <p>$<%= item.price %></p>
+      <p><%= number_to_currency(item.price) %></p>
       <p>Quantity: <%= quantity %></p>
-      <p>Subtotal: $<%= cart.subtotal(item) %></p>
+      <p>Subtotal: <%= number_to_currency(cart.subtotal(item)) %></p>
     </div>
   <% end %>
 
-  <h2>Grand Total: $<%= cart.grand_total %></h2>
+  <h2>Grand Total: <%= number_to_currency(cart.grand_total) %></h2>
 
   <%= button_to "Empty Cart", { controller: :carts, action: :destroy }, method: :delete %>
 <% else %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -23,7 +23,7 @@
 <% @items.each do |item| %>
   <section id="item-id-<%= item.id %>">
     <p><%= link_to item.name, item_path(item) %></p>
-    <p>$<%= item.price %></p>
+    <p><%= number_to_currency(item.price) %></p>
     <p>Description: <%= item.description %></p>
     <%= image_tag item.image || @default_image, alt: "image of #{item.name}" %>
     <p><%= item.inventory %> in stock</p>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -3,7 +3,7 @@
 <p>Description: <%= @item.description %></p>
 <p>Merchant Name: <%= @merchant.name %></p>
 <p><%= @item.inventory %> in stock</p>
-<p>$<%= @item.price %></p>
+<p><%= number_to_currency(@item.price) %></p>
 <p>Average Fulfillment Time: <%= @item.average_fulfillment_time %> days</p>
 
 <% if (current_user == nil) || current_user.user? %>

--- a/spec/features/carts/show_spec.rb
+++ b/spec/features/carts/show_spec.rb
@@ -26,21 +26,21 @@ RSpec.describe "cart show page", type: :feature do
         expect(page).to have_link(@item_1.name)
         expect(page).to have_css("img[src*='#{@item_1.image}']")
         expect(page).to have_content(@item_1.user.name)
-        expect(page).to have_content("$#{@item_1.price}")
+        expect(page).to have_content(number_to_currency(@item_1.price))
         expect(page).to have_content("Quantity: 2")
-        expect(page).to have_content("Subtotal: $#{2 * @item_1.price}")
+        expect(page).to have_content("Subtotal: #{number_to_currency(2 * @item_1.price)}")
       end
 
       within("#item-#{@item_2.id}") do
         expect(page).to have_link(@item_2.name)
         expect(page).to have_css("img[src*='#{@item_2.image}']")
         expect(page).to have_content(@item_2.user.name)
-        expect(page).to have_content("$#{@item_2.price}")
+        expect(page).to have_content(number_to_currency(@item_2.price))
         expect(page).to have_content("Quantity: 1")
-        expect(page).to have_content("Subtotal: $#{@item_2.price}")
+        expect(page).to have_content("Subtotal: #{number_to_currency(@item_2.price)}")
       end
 
-      expect(page).to have_content("Grand Total: $#{ 2 * @item_1.price +  @item_2.price }")
+      expect(page).to have_content("Grand Total: #{number_to_currency(2 * @item_1.price +  @item_2.price)}")
     end
 
     it "I click on Empty Cart, all items are removed" do
@@ -84,21 +84,21 @@ RSpec.describe "cart show page", type: :feature do
         expect(page).to have_link(@item_1.name)
         expect(page).to have_css("img[src*='#{@item_1.image}']")
         expect(page).to have_content(@item_1.user.name)
-        expect(page).to have_content("$#{@item_1.price}")
+        expect(page).to have_content(number_to_currency(@item_1.price))
         expect(page).to have_content("Quantity: 2")
-        expect(page).to have_content("Subtotal: $#{2 * @item_1.price}")
+        expect(page).to have_content("Subtotal: #{number_to_currency(2 * @item_1.price)}")
       end
 
       within("#item-#{@item_2.id}") do
         expect(page).to have_link(@item_2.name)
         expect(page).to have_css("img[src*='#{@item_2.image}']")
         expect(page).to have_content(@item_2.user.name)
-        expect(page).to have_content("$#{@item_2.price}")
+        expect(page).to have_content(number_to_currency(@item_2.price))
         expect(page).to have_content("Quantity: 1")
-        expect(page).to have_content("Subtotal: $#{@item_2.price}")
+        expect(page).to have_content("Subtotal: #{number_to_currency(@item_2.price)}")
       end
 
-      expect(page).to have_content("Grand Total: $#{ 2 * @item_1.price +  @item_2.price }")
+      expect(page).to have_content("Grand Total: #{number_to_currency(2 * @item_1.price +  @item_2.price)}")
     end
 
     it "I click on Empty Cart, all items are removed" do

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "items index page, " do
 
       within "#item-id-#{@item_1.id}" do
         expect(page).to have_link(@item_1.name)
-        expect(page).to have_content("$#{@item_1.price}")
+        expect(page).to have_content(number_to_currency(@item_1.price))
         expect(page).to have_content("Description: #{@item_1.description}")
         expect(page).to have_css("img[src*='#{@item_1.image}']")
         expect(page).to have_content("#{@item_1.inventory} in stock")
@@ -27,7 +27,7 @@ RSpec.describe "items index page, " do
 
       within "#item-id-#{@item_2.id}" do
         expect(page).to have_link(@item_2.name)
-        expect(page).to have_content("$#{@item_2.price}")
+        expect(page).to have_content(number_to_currency(@item_2.price))
         expect(page).to have_content("Description: #{@item_2.description}")
         expect(page).to have_css("img[src*='#{@item_2.image}']")
         expect(page).to have_content("#{@item_2.inventory} in stock")

--- a/spec/features/items/show_spec.rb
+++ b/spec/features/items/show_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "As any kind of user, " do
       expect(page).to have_css("img[src*='#{@item_1.image}']")
       expect(page).to have_content(@merchant_1.name)
       expect(page).to have_content(@item_1.inventory)
-      expect(page).to have_content(@item_1.price)
+      expect(page).to have_content(number_to_currency(@item_1.price))
       expect(page).to have_content(@item_1.average_fulfillment_time)
       expect(page).to have_button("Add to Cart")
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -81,4 +81,5 @@ RSpec.configure do |config|
     end
   end
 
+  include ActionView::Helpers::NumberHelper
 end


### PR DESCRIPTION
No user stories closed -- just uses `number_to_currency` in the views and feature tests (added `include ActionView::Helpers::NumberHelper` to `rails_helper` so we can use it in all the tests). We should use this method in the future whenever we have prices in our views!