### PR TITLE
User stories 48 & 49

### DIFF
--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -9,12 +9,12 @@ class Merchant::ItemsController < Merchant::BaseController
 
   def create
     @item = current_user.items.new(item_params)
-    if @item.save!
+    if @item.save
       flash[:success] = "#{@item.name} has been added"
       redirect_to merchant_items_path
     else
       flash[:error] = @item.errors.full_messages.join(". ")
-      render :new
+      redirect_to new_merchant_item_path
     end
   end
 

--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -14,7 +14,7 @@ class Merchant::ItemsController < Merchant::BaseController
       redirect_to merchant_items_path
     else
       flash[:error] = @item.errors.full_messages.join(". ")
-      redirect_to new_merchant_item_path
+      render :new
     end
   end
 

--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -4,7 +4,7 @@ class Merchant::ItemsController < Merchant::BaseController
   end
 
   def new
-    @item = Item.new(user: current_user)
+    @item = current_user.items.new
   end
 
   def create

--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -1,6 +1,6 @@
 class Merchant::ItemsController < Merchant::BaseController
   def index
-    @items = current_user.items
+    @items = current_user.items.where.not(id: nil)
   end
 
   def new

--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -4,6 +4,7 @@ class Merchant::ItemsController < Merchant::BaseController
   end
 
   def new
+    @item = Item.new
   end
 
   def disable

--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -43,6 +43,10 @@ class Merchant::ItemsController < Merchant::BaseController
   private
 
   def item_params
-    params.require(:item).permit(:name, :description, :image, :price, :inventory)
+    if params[:item][:image] == ""
+      params.require(:item).permit(:name, :description, :price, :inventory)
+    else
+      params.require(:item).permit(:name, :description, :image, :price, :inventory)
+    end
   end
 end

--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -4,7 +4,18 @@ class Merchant::ItemsController < Merchant::BaseController
   end
 
   def new
-    @item = Item.new
+    @item = Item.new(user: current_user)
+  end
+
+  def create
+    @item = current_user.items.new(item_params)
+    if @item.save!
+      flash[:success] = "#{@item.name} has been added"
+      redirect_to merchant_items_path
+    else
+      flash[:error] = @item.errors.full_messages.join(". ")
+      render :new
+    end
   end
 
   def disable
@@ -27,5 +38,11 @@ class Merchant::ItemsController < Merchant::BaseController
     end
 
     redirect_to merchant_items_path
+  end
+
+  private
+
+  def item_params
+    params.require(:item).permit(:name, :description, :image, :price, :inventory)
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,7 +2,6 @@ class Item < ApplicationRecord
   validates_presence_of :name,
                        :price,
                        :description,
-                       :image,
                        :inventory
 
   belongs_to :user

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,12 +1,15 @@
 class Item < ApplicationRecord
-  validates_presence_of :name,
-                       :price,
-                       :description,
-                       :inventory
-
   belongs_to :user
   has_many :order_items
   has_many :orders, through: :order_items
+
+  validates_presence_of :name,
+                        :price,
+                        :description,
+                        :inventory
+
+  validates :price, numericality: { greater_than_or_equal_to: 0.0 }
+  validates :inventory, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
   DEFAULT_IMAGE = "https://www.ultimate-realty.com/wp-content/uploads/sites/6518/2019/04/Image-Coming-Soon.png"
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,7 +8,7 @@ class Item < ApplicationRecord
                         :description,
                         :inventory
 
-  validates :price, numericality: { greater_than_or_equal_to: 0.0 }
+  validates :price, numericality: { greater_than_or_equal_to: 0.01 }
   validates :inventory, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
   DEFAULT_IMAGE = "https://www.ultimate-realty.com/wp-content/uploads/sites/6518/2019/04/Image-Coming-Soon.png"

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -27,7 +27,9 @@ class Item < ApplicationRecord
   end
 
   def average_fulfillment_time
-    order_items.average("updated_at - created_at").to_i
+    if order_items.where("order_items.fulfilled").count > 0
+      order_items.where("order_items.fulfilled").average("updated_at - created_at").to_i
+    end
   end
 
   def order_count

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -74,5 +74,6 @@ class Order < ApplicationRecord
         .where(status: 0)
         .where("items.user_id = ?", merchant.id)
         .distinct
+        .order(:id)
   end
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,7 +4,9 @@
 <p>Merchant Name: <%= @merchant.name %></p>
 <p><%= @item.inventory %> in stock</p>
 <p><%= number_to_currency(@item.price) %></p>
-<p>Average Fulfillment Time: <%= @item.average_fulfillment_time %> days</p>
+<% if @item.average_fulfillment_time %>
+  <p>Average Fulfillment Time: <%= @item.average_fulfillment_time %> days</p>
+<% end %>
 
 <% if (current_user == nil) || current_user.user? %>
   <%= button_to "Add to Cart", cart_add_item_path(@item)  %>

--- a/app/views/merchant/items/new.html.erb
+++ b/app/views/merchant/items/new.html.erb
@@ -1,4 +1,4 @@
-<%= form_for [current_user, @item], url: new_merchant_item_path, method: :patch do |f| %>
+<%= form_for @item, url: merchant_items_path do |f| %>
 
   <%= f.label :name %>
   <%= f.text_field :name, required: true %><br>
@@ -10,7 +10,7 @@
   <%= f.text_field :image %><br>
 
   <%= f.label :price %>
-  <%= f.number_field :price, required: true, min: 0.01 %><br>
+  <%= f.number_field :price, required: true, min: 0.01, step: 0.01 %><br>
 
   <%= f.label :inventory %>
   <%= f.number_field :inventory, required: true, min: 0 %><br>

--- a/app/views/merchant/items/new.html.erb
+++ b/app/views/merchant/items/new.html.erb
@@ -1,0 +1,19 @@
+<%= form_for [current_user, @item], url: new_merchant_item_path, method: :patch do |f| %>
+
+  <%= f.label :name %>
+  <%= f.text_field :name, required: true %><br>
+
+  <%= f.label :description %>
+  <%= f.text_area :description, required: true %><br>
+
+  <%= f.label "Thumbnail URL" %>
+  <%= f.text_field :image %><br>
+
+  <%= f.label :price %>
+  <%= f.number_field :price, required: true, min: 0.01 %><br>
+
+  <%= f.label :inventory %>
+  <%= f.number_field :inventory, required: true, min: 0 %><br>
+
+  <%= f.submit %>
+<% end %>

--- a/app/views/merchant/items/new.html.erb
+++ b/app/views/merchant/items/new.html.erb
@@ -9,7 +9,7 @@
   <%= f.label :image, "Thumbnail URL" %>
   <%= f.text_field :image %><br>
 
-  <%= f.label :price %>
+  <%= f.label :price, "Price in Dollars" %>
   <%= f.number_field :price, required: true, min: 0.01, step: 0.01 %><br>
 
   <%= f.label :inventory %>

--- a/app/views/merchant/items/new.html.erb
+++ b/app/views/merchant/items/new.html.erb
@@ -6,7 +6,7 @@
   <%= f.label :description %>
   <%= f.text_area :description, required: true %><br>
 
-  <%= f.label "Thumbnail URL" %>
+  <%= f.label :image, "Thumbnail URL" %>
   <%= f.text_field :image %><br>
 
   <%= f.label :price %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,7 @@ Rails.application.routes.draw do
   # DASHBOARD ROUTES (AS A MERCHANT)
   scope :dashboard, module: :merchant, as: :merchant do
     get '/', to: "merchants#show", as: :dashboard
-    resources :items, only: [:index, :new, :edit]
+    resources :items, only: [:index, :new, :create, :edit]
     patch '/items/:id/disable', to: "items#disable", as: :disable_item
     patch '/items/:id/enable', to: "items#enable", as: :enable_item
     delete '/items/:id', to: "items#destroy", as: :delete_item

--- a/spec/features/merchant/items/index_spec.rb
+++ b/spec/features/merchant/items/index_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe "Merchant Items Index", type: :feature do
     it "has info for all the items I'm selling" do
       visit merchant_items_path
 
-      expect(page).to have_link("Add a New Item")
       expect(page).to_not have_content(@other_merchant_item.id)
 
       within("#item-#{@active_never_ordered_item.id}") do
@@ -80,6 +79,14 @@ RSpec.describe "Merchant Items Index", type: :feature do
         expect(page).to_not have_button("Disable Item")
         expect(page).to_not have_button("Delete Item")
       end
+    end
+
+    it "has a link to the new item form" do
+      visit merchant_items_path
+
+      click_link("Add a New Item")
+
+      expect(current_path).to eq(new_merchant_item_path)
     end
   end
 end

--- a/spec/features/merchant/items/new_spec.rb
+++ b/spec/features/merchant/items/new_spec.rb
@@ -45,12 +45,10 @@ RSpec.describe "Merchant Adds an Item", type: :feature do
       end
     end
 
-    it "I cannot leave most field blank" do
+    it "I cannot leave the name field blank" do
       visit new_merchant_item_path
 
-      expect(current_path).to eq('/dashboard/items/new')
-
-      # DON'T fill_in "item[name]", with: "Big Couch"
+      # DON'T fill_in "item[name]"
       fill_in "item[description]", with: "It's a very large couch"
       fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
       fill_in "item[price]", with: "50.00"
@@ -61,9 +59,13 @@ RSpec.describe "Merchant Adds an Item", type: :feature do
       expect(page).to have_field "item[description]"
       expect(page).to have_content("Name can't be blank")
       expect(Item.count).to eq(0)
+    end
+
+    it "I cannot leave the description field blank" do
+      visit new_merchant_item_path
 
       fill_in "item[name]", with: "Big Couch"
-      # DON'T fill_in "item[description]", with: "It's a very large couch"
+      # DON'T fill_in "item[description]"
       fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
       fill_in "item[price]", with: "50.00"
       fill_in "item[inventory]", with: "75"
@@ -74,10 +76,15 @@ RSpec.describe "Merchant Adds an Item", type: :feature do
       expect(page).to have_content("Description can't be blank")
       expect(Item.count).to eq(0)
 
+    end
+
+    it "I cannot leave the price field blank" do
+      visit new_merchant_item_path
+
       fill_in "item[name]", with: "Big Couch"
       fill_in "item[description]", with: "It's a very large couch"
       fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
-      # DON'T fill_in "item[price]", with: "50.00"
+      # DON'T fill_in "item[price]"
       fill_in "item[inventory]", with: "75"
 
       click_on "Create Item"
@@ -85,12 +92,16 @@ RSpec.describe "Merchant Adds an Item", type: :feature do
       expect(page).to have_field "item[description]"
       expect(page).to have_content("Price can't be blank")
       expect(Item.count).to eq(0)
+    end
+
+    it "I cannot leave the inventory field blank" do
+      visit new_merchant_item_path
 
       fill_in "item[name]", with: "Big Couch"
       fill_in "item[description]", with: "It's a very large couch"
       fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
       fill_in "item[price]", with: "50.00"
-      # DON'T fill_in "item[inventory]", with: "75"
+      # DON'T fill_in "item[inventory]"
 
       click_on "Create Item"
 
@@ -106,7 +117,7 @@ RSpec.describe "Merchant Adds an Item", type: :feature do
 
       fill_in "item[name]", with: "Big Couch"
       fill_in "item[description]", with: "It's a very large couch"
-      # DON'T fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
+      # DON'T fill_in "item[image]"
       fill_in "item[price]", with: "50.00"
       fill_in "item[inventory]", with: "75"
 

--- a/spec/features/merchant/items/new_spec.rb
+++ b/spec/features/merchant/items/new_spec.rb
@@ -45,8 +45,58 @@ RSpec.describe "Merchant Adds an Item", type: :feature do
       end
     end
 
-    xit "I cannot leave most field blank" do
-      # to-do
+    it "I cannot leave most field blank" do
+      visit new_merchant_item_path
+
+      expect(current_path).to eq('/dashboard/items/new')
+
+      # DON'T fill_in "item[name]", with: "Big Couch"
+      fill_in "item[description]", with: "It's a very large couch"
+      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
+      fill_in "item[price]", with: "50.00"
+      fill_in "item[inventory]", with: "75"
+
+      click_on "Create Item"
+
+      expect(page).to have_field "item[description]"
+      expect(page).to have_content("Name can't be blank")
+      expect(Item.count).to eq(0)
+
+      fill_in "item[name]", with: "Big Couch"
+      # DON'T fill_in "item[description]", with: "It's a very large couch"
+      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
+      fill_in "item[price]", with: "50.00"
+      fill_in "item[inventory]", with: "75"
+
+      click_on "Create Item"
+
+      expect(page).to have_field "item[description]"
+      expect(page).to have_content("Description can't be blank")
+      expect(Item.count).to eq(0)
+
+      fill_in "item[name]", with: "Big Couch"
+      fill_in "item[description]", with: "It's a very large couch"
+      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
+      # DON'T fill_in "item[price]", with: "50.00"
+      fill_in "item[inventory]", with: "75"
+
+      click_on "Create Item"
+
+      expect(page).to have_field "item[description]"
+      expect(page).to have_content("Price can't be blank")
+      expect(Item.count).to eq(0)
+
+      fill_in "item[name]", with: "Big Couch"
+      fill_in "item[description]", with: "It's a very large couch"
+      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
+      fill_in "item[price]", with: "50.00"
+      # DON'T fill_in "item[inventory]", with: "75"
+
+      click_on "Create Item"
+
+      expect(page).to have_field "item[description]"
+      expect(page).to have_content("Inventory can't be blank")
+      expect(Item.count).to eq(0)
     end
 
     xit "I can leave thumbnail URL blank" do

--- a/spec/features/merchant/items/new_spec.rb
+++ b/spec/features/merchant/items/new_spec.rb
@@ -99,9 +99,34 @@ RSpec.describe "Merchant Adds an Item", type: :feature do
       expect(Item.count).to eq(0)
     end
 
-    xit "I can leave thumbnail URL blank" do
-      # to-do
-      expect(page).to have_css("img[src*='#{Item::DEFAULT_IMAGE}']")
+    it "I can leave thumbnail URL blank" do
+      visit new_merchant_item_path
+
+      expect(current_path).to eq('/dashboard/items/new')
+
+      fill_in "item[name]", with: "Big Couch"
+      fill_in "item[description]", with: "It's a very large couch"
+      # DON'T fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
+      fill_in "item[price]", with: "50.00"
+      fill_in "item[inventory]", with: "75"
+
+      click_on "Create Item"
+      save_and_open_page
+
+      expect(current_path).to eq(merchant_items_path)
+
+      new_item = Item.last
+
+      expect(page).to have_content("#{new_item.name} has been added")
+
+      within("#item-#{new_item.id}") do
+        expect(page).to have_link(new_item.name)
+        expect(page).to have_content("ID: #{new_item.id}")
+        expect(page).to have_css("img[src*='#{Item::DEFAULT_IMAGE}']")
+        expect(page).to have_content(number_to_currency(new_item.price))
+        expect(page).to have_content("#{new_item.inventory} in stock")
+        expect(page).to have_button("Disable Item")
+      end
     end
 
     xit "Price must be > 0.00" do

--- a/spec/features/merchant/items/new_spec.rb
+++ b/spec/features/merchant/items/new_spec.rb
@@ -158,8 +158,52 @@ RSpec.describe "Merchant Adds an Item", type: :feature do
       expect(Item.count).to eq(0)
     end
 
-    xit "Inventory must be >= 0" do
-      # to-do
+    it "Inventory must be an integer >= 0" do
+      visit new_merchant_item_path
+
+      expect(current_path).to eq('/dashboard/items/new')
+
+      fill_in "item[name]", with: "Big Couch"
+      fill_in "item[description]", with: "It's a very large couch"
+      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
+      fill_in "item[price]", with: "5"
+      fill_in "item[inventory]", with: "-6"
+
+      click_on "Create Item"
+
+      expect(page).to have_field "item[description]"
+      expect(page).to have_content("Inventory must be greater than or equal to 0")
+      expect(Item.count).to eq(0)
+
+      fill_in "item[name]", with: "Big Couch"
+      fill_in "item[description]", with: "It's a very large couch"
+      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
+      fill_in "item[price]", with: "5.00"
+      fill_in "item[inventory]", with: "5.6"
+
+      click_on "Create Item"
+
+      expect(page).to have_field "item[description]"
+      expect(page).to have_content("Inventory must be an integer")
+      expect(Item.count).to eq(0)
+
+      fill_in "item[name]", with: "Big Couch"
+      fill_in "item[description]", with: "It's a very large couch"
+      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
+      fill_in "item[price]", with: "5.00"
+      fill_in "item[inventory]", with: "0"
+
+      click_on "Create Item"
+
+      expect(current_path).to eq(merchant_items_path)
+
+      new_item = Item.last
+
+      expect(page).to have_content("#{new_item.name} has been added")
+
+      within("#item-#{new_item.id}") do
+        expect(page).to have_link(new_item.name)
+      end
     end
   end
 end

--- a/spec/features/merchant/items/new_spec.rb
+++ b/spec/features/merchant/items/new_spec.rb
@@ -111,7 +111,6 @@ RSpec.describe "Merchant Adds an Item", type: :feature do
       fill_in "item[inventory]", with: "75"
 
       click_on "Create Item"
-      save_and_open_page
 
       expect(current_path).to eq(merchant_items_path)
 
@@ -129,11 +128,37 @@ RSpec.describe "Merchant Adds an Item", type: :feature do
       end
     end
 
-    xit "Price must be > 0.00" do
-      # to-do
+    it "Price must be >= 0.00" do
+      visit new_merchant_item_path
+
+      expect(current_path).to eq('/dashboard/items/new')
+
+      fill_in "item[name]", with: "Big Couch"
+      fill_in "item[description]", with: "It's a very large couch"
+      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
+      fill_in "item[price]", with: "-5.0"
+      fill_in "item[inventory]", with: "75"
+
+      click_on "Create Item"
+
+      expect(page).to have_field "item[description]"
+      expect(page).to have_content("Price must be greater than or equal to 0.0")
+      expect(Item.count).to eq(0)
+
+      # fill_in "item[name]", with: "Big Couch"
+      # fill_in "item[description]", with: "It's a very large couch"
+      # fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
+      # fill_in "item[price]", with: "0.00"
+      # fill_in "item[inventory]", with: "75"
+      #
+      # click_on "Create Item"
+      #
+      # expect(page).to have_field "item[description]"
+      # expect(page).to have_content("SOME ERROR")
+      # expect(Item.count).to eq(0)
     end
 
-    xit "Quantity must be >= 0" do
+    xit "Inventory must be >= 0" do
       # to-do
     end
   end

--- a/spec/features/merchant/items/new_spec.rb
+++ b/spec/features/merchant/items/new_spec.rb
@@ -15,5 +15,51 @@ RSpec.describe "Merchant Adds an Item", type: :feature do
 
       expect(current_path).to eq(new_merchant_item_path)
     end
+
+    it "I can add a new item by filling out a form" do
+      visit new_merchant_item_path
+
+      expect(current_path).to eq('/dashboard/items/new')
+
+      fill_in "item[name]", with: "Big Couch"
+      fill_in "item[description]", with: "It's a very large couch"
+      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
+      fill_in "item[price]", with: "50.00"
+      fill_in "item[inventory]", with: "75"
+
+      click_on "Create Item"
+
+      expect(current_path).to eq(merchant_items_path)
+
+      new_item = Item.last
+
+      expect(page).to have_content("#{new_item.name} has been added")
+
+      within("#item-#{new_item.id}") do
+        expect(page).to have_link(new_item.name)
+        expect(page).to have_content("ID: #{new_item.id}")
+        expect(page).to have_css("img[src*='#{new_item.image}']")
+        expect(page).to have_content(number_to_currency(new_item.price))
+        expect(page).to have_content("#{new_item.inventory} in stock")
+        expect(page).to have_button("Disable Item")
+      end
+    end
+
+    xit "I cannot leave most field blank" do
+      # to-do
+    end
+
+    xit "I can leave thumbnail URL blank" do
+      # to-do
+      expect(page).to have_css("img[src*='#{Item::DEFAULT_IMAGE}']")
+    end
+
+    xit "Price must be > 0.00" do
+      # to-do
+    end
+
+    xit "Quantity must be >= 0" do
+      # to-do
+    end
   end
 end

--- a/spec/features/merchant/items/new_spec.rb
+++ b/spec/features/merchant/items/new_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe "Merchant Adds an Item", type: :feature do
       end
     end
 
-    it "Price must be >= 0.00" do
+    it "Price must be > 0.00" do
       visit new_merchant_item_path
 
       expect(current_path).to eq('/dashboard/items/new')
@@ -142,20 +142,20 @@ RSpec.describe "Merchant Adds an Item", type: :feature do
       click_on "Create Item"
 
       expect(page).to have_field "item[description]"
-      expect(page).to have_content("Price must be greater than or equal to 0.0")
+      expect(page).to have_content("Price must be greater than or equal to 0.01")
       expect(Item.count).to eq(0)
 
-      # fill_in "item[name]", with: "Big Couch"
-      # fill_in "item[description]", with: "It's a very large couch"
-      # fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
-      # fill_in "item[price]", with: "0.00"
-      # fill_in "item[inventory]", with: "75"
-      #
-      # click_on "Create Item"
-      #
-      # expect(page).to have_field "item[description]"
-      # expect(page).to have_content("SOME ERROR")
-      # expect(Item.count).to eq(0)
+      fill_in "item[name]", with: "Big Couch"
+      fill_in "item[description]", with: "It's a very large couch"
+      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
+      fill_in "item[price]", with: "0.00"
+      fill_in "item[inventory]", with: "75"
+
+      click_on "Create Item"
+
+      expect(page).to have_field "item[description]"
+      expect(page).to have_content("Price must be greater than or equal to 0.01")
+      expect(Item.count).to eq(0)
     end
 
     xit "Inventory must be >= 0" do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Item, type: :model do
     it {should validate_presence_of :name}
     it {should validate_presence_of :price}
     it {should validate_presence_of :description}
-    it {should validate_presence_of :image}
     it {should validate_presence_of :inventory}
   end
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Item, type: :model do
     it {should validate_presence_of :description}
     it {should validate_presence_of :inventory}
 
-    it {should validate_numericality_of(:price).is_greater_than_or_equal_to(0.00)}
+    it {should validate_numericality_of(:price).is_greater_than_or_equal_to(0.01)}
     it {should validate_numericality_of(:inventory).only_integer}
     it {should validate_numericality_of(:inventory).is_greater_than_or_equal_to(0)}
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -79,8 +79,13 @@ RSpec.describe Item, type: :model do
       order_item_1 = create(:fulfilled_order_item, item: item_1, created_at: 3.days.ago, updated_at: 1.days.ago)
       order_item_2 = create(:fulfilled_order_item, item: item_1, created_at: 2.days.ago, updated_at: 1.days.ago)
       order_item_3 = create(:fulfilled_order_item, item: item_1, created_at: 4.days.ago, updated_at: 1.days.ago)
+      # not fulfilled: should not be included
+      order_item_4 = create(:order_item, item: item_1, created_at: 1.days.ago, updated_at: 1.days.ago)
 
       expect(item_1.average_fulfillment_time).to eq(2)
+
+      item_2 = create(:item, user: merchant_1)
+      expect(item_2.average_fulfillment_time).to eq(nil)
     end
 
     it "#order_count returns how many orders include that item" do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe Item, type: :model do
     it {should validate_presence_of :price}
     it {should validate_presence_of :description}
     it {should validate_presence_of :inventory}
+
+    it {should validate_numericality_of(:price).is_greater_than_or_equal_to(0.00)}
+    it {should validate_numericality_of(:inventory).only_integer}
+    it {should validate_numericality_of(:inventory).is_greater_than_or_equal_to(0)}
   end
 
   describe 'relationships' do


### PR DESCRIPTION
Closes User Stories 48 (#35) & 49 (#34) - merchant adds a new item using a form (& validations thereof)

Feature tests(%) - 100
Model tests(%) - 100
Commented Hard to Understand Areas? Y

Comments:
 - If you do save and open page after failed item creation (which you can only get to if you use Capybara -- an actual browser won't let you submit bad parameters / blank fields), it doesn't actually re-populate the fields. Can you see what's different versus your user creation form? The only thing I can think of is that we're doing `@item = current_user.items.new` vs `@item = Item.new` so maybe it's not reloading the same instance of @item?
 - Changed `Item#average_fulfillment_time` to only consider fulfilled order_items when calculating, and return nil if the item has no fulfilled order_items. Only show the average fulfillment time on the item show page if it actually has fulfilled order_items.
 - Don't validate presence of `Item.image` -- it can be nil -- will lead to default image being displayed
 - Validate numericality of `Item.inventory` (integer >= 0) and `Item.price` (>= 0.01)