### PR TITLE
User stories 50 & 51

### DIFF
--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -46,6 +46,9 @@ class Merchant::ItemsController < Merchant::BaseController
     redirect_to merchant_items_path
   end
 
+  def edit
+  end
+
   private
 
   def item_params

--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -61,10 +61,13 @@ class Merchant::ItemsController < Merchant::BaseController
       return
     end
 
-    @item.update(item_params)
-
-    flash[:success] = "#{@item.name} has been updated"
-    redirect_to merchant_items_path
+    if @item.update(update_params)
+      flash[:success] = "#{@item.name} has been updated"
+      redirect_to merchant_items_path
+    else
+      flash[:error] = @item.errors.full_messages.join(". ")
+      render :edit
+    end
   end
 
   private
@@ -75,5 +78,13 @@ class Merchant::ItemsController < Merchant::BaseController
     else
       params.require(:item).permit(:name, :description, :image, :price, :inventory)
     end
+  end
+
+  def update_params
+    altered_params = params
+    if params[:item][:image] == ""
+      altered_params[:item][:image] = nil
+    end
+    altered_params.require(:item).permit(:name, :description, :image, :price, :inventory)
   end
 end

--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -48,6 +48,13 @@ class Merchant::ItemsController < Merchant::BaseController
 
   def edit
     @item = Item.find(params[:id])
+    if @item.user != current_user
+      render file: "/public/404", status: 404
+    end
+  end
+
+  def update
+    redirect_to merchant_items_path
   end
 
   private

--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -47,6 +47,7 @@ class Merchant::ItemsController < Merchant::BaseController
   end
 
   def edit
+    @item = Item.find(params[:id])
   end
 
   private

--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -50,10 +50,20 @@ class Merchant::ItemsController < Merchant::BaseController
     @item = Item.find(params[:id])
     if @item.user != current_user
       render file: "/public/404", status: 404
+      return
     end
   end
 
   def update
+    @item = Item.find(params[:id])
+    if @item.user != current_user
+      render file: "/public/404", status: 404
+      return
+    end
+
+    @item.update(item_params)
+
+    flash[:success] = "#{@item.name} has been updated"
     redirect_to merchant_items_path
   end
 

--- a/app/views/merchant/items/edit.html.erb
+++ b/app/views/merchant/items/edit.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @item, url: merchant_items_path do |f| %>
+<%= form_for @item, url: merchant_item_path(@item) do |f| %>
 
   <%= f.label :name %>
   <%= f.text_field :name, required: true %><br>

--- a/app/views/merchant/items/edit.html.erb
+++ b/app/views/merchant/items/edit.html.erb
@@ -1,0 +1,19 @@
+<%= form_for @item, url: merchant_items_path do |f| %>
+
+  <%= f.label :name %>
+  <%= f.text_field :name, required: true %><br>
+
+  <%= f.label :description %>
+  <%= f.text_area :description, required: true %><br>
+
+  <%= f.label :image, "Thumbnail URL" %>
+  <%= f.text_field :image %><br>
+
+  <%= f.label :price, "Price in Dollars" %>
+  <%= f.number_field :price, required: true, min: 0.01, step: 0.01 %><br>
+
+  <%= f.label :inventory %>
+  <%= f.number_field :inventory, required: true, min: 0 %><br>
+
+  <%= f.submit %>
+<% end %>

--- a/app/views/merchant/items/index.html.erb
+++ b/app/views/merchant/items/index.html.erb
@@ -9,7 +9,7 @@
     <p>ID: <%= item.id %></p>
     <p><%= number_to_currency(item.price) %></p>
     <p><%= item.inventory %> in stock</p>
-    <%= button_to "Edit Item", edit_merchant_item_path(item) %>
+    <%= button_to "Edit Item", edit_merchant_item_path(item), method: "get" %>
 
     <% if item.reload.active %>
       <%= button_to "Disable Item", merchant_disable_item_path(item), method: "patch", data: { confirm: 'Are you sure?', disable_with: 'loading...' } %>
@@ -18,7 +18,7 @@
     <% end %>
 
     <% if item.order_count == 0 %>
-      <%= button_to "Delete Item", merchant_delete_item_path(item), method: "delete", data: { confirm: 'Are you sure?', disable_with: 'loading...' } %>
+      <%= button_to "Delete Item", merchant_item_path(item), method: "delete", data: { confirm: 'Are you sure?', disable_with: 'loading...' } %>
     <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,10 +41,9 @@ Rails.application.routes.draw do
   # DASHBOARD ROUTES (AS A MERCHANT)
   scope :dashboard, module: :merchant, as: :merchant do
     get '/', to: "merchants#show", as: :dashboard
-    resources :items, only: [:index, :new, :create, :edit]
+    resources :items, only: [:index, :new, :create, :edit, :destroy]
     patch '/items/:id/disable', to: "items#disable", as: :disable_item
     patch '/items/:id/enable', to: "items#enable", as: :enable_item
-    delete '/items/:id', to: "items#destroy", as: :delete_item
     patch '/order_items/:id/fulfill', to: 'order_items#fulfill', as: :fulfill_item
     resources :orders, only: :show
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,7 @@ Rails.application.routes.draw do
   # DASHBOARD ROUTES (AS A MERCHANT)
   scope :dashboard, module: :merchant, as: :merchant do
     get '/', to: "merchants#show", as: :dashboard
-    resources :items, only: [:index, :new, :create, :edit, :destroy]
+    resources :items, only: [:index, :new, :create, :edit, :update, :destroy]
     patch '/items/:id/disable', to: "items#disable", as: :disable_item
     patch '/items/:id/enable', to: "items#enable", as: :enable_item
     patch '/order_items/:id/fulfill', to: 'order_items#fulfill', as: :fulfill_item

--- a/spec/features/merchant/items/edit_spec.rb
+++ b/spec/features/merchant/items/edit_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe "Merchant Edits an Item", type: :feature do
       expect(page).to have_content("Name can't be blank")
     end
 
-    xit "I cannot leave the description field blank" do
+    it "I cannot leave the description field blank" do
       visit edit_merchant_item_path(@item)
 
       fill_in "item[description]", with: ""
@@ -174,7 +174,7 @@ RSpec.describe "Merchant Edits an Item", type: :feature do
       expect(page).to have_content("Description can't be blank")
     end
 
-    xit "I cannot leave the price field blank" do
+    it "I cannot leave the price field blank" do
       visit edit_merchant_item_path(@item)
 
       fill_in "item[price]", with: ""
@@ -184,7 +184,7 @@ RSpec.describe "Merchant Edits an Item", type: :feature do
       expect(page).to have_content("Price can't be blank")
     end
 
-    xit "I cannot leave the inventory field blank" do
+    it "I cannot leave the inventory field blank" do
       visit edit_merchant_item_path(@item)
 
       fill_in "item[inventory]", with: ""
@@ -194,10 +194,8 @@ RSpec.describe "Merchant Edits an Item", type: :feature do
       expect(page).to have_content("Inventory can't be blank")
     end
 
-    xit "I can leave thumbnail URL blank" do
+    it "I can leave thumbnail URL blank" do
       visit edit_merchant_item_path(@item)
-
-      expect(current_path).to eq('/dashboard/items/new')
 
       fill_in "item[image]", with: ""
       click_on "Update Item"
@@ -211,7 +209,7 @@ RSpec.describe "Merchant Edits an Item", type: :feature do
       end
     end
 
-    xit "Price must be > 0.00" do
+    it "Price must be > 0.00" do
       visit edit_merchant_item_path(@item)
 
       fill_in "item[price]", with: "-5.0"

--- a/spec/features/merchant/items/edit_spec.rb
+++ b/spec/features/merchant/items/edit_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Merchant Edits an Item", type: :feature do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
     end
 
-    xit 'I can get to the edit item page from the merchant items index' do
+    it 'I can get to the edit item page from the merchant items index' do
       visit merchant_items_path
 
       within("#item-#{@item.id}") do

--- a/spec/features/merchant/items/edit_spec.rb
+++ b/spec/features/merchant/items/edit_spec.rb
@@ -1,0 +1,63 @@
+# The form is re-populated with all of this item's information
+# I can change any information, but all of the rules for adding a new item still apply:
+# - name and description cannot be blank
+# - price cannot be less than $0.00
+# - inventory must be 0 or greater
+#
+# When I submit the form
+# I am taken back to my items page
+# I see a flash message indicating my item is updated
+# I see the item's new information on the page, and it maintains its previous enabled/disabled state
+# If I left the image field blank, I see a placeholder image for the thumbnail
+
+require 'rails_helper'
+
+RSpec.describe "Merchant Edits an Item", type: :feature do
+  context "as a merchant" do
+    before(:each) do
+      @merchant = create(:merchant)
+      @item = create(:item, user: @merchant)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
+    end
+
+    xit 'I can get to the edit item page from the merchant items index' do
+      visit merchant_items_path
+
+      within("#item-#{@item.id}") do
+        click_button "Edit Item"
+      end
+
+      expect(current_path).to eq(edit_merchant_item_path(@item))
+    end
+  end
+
+  xit "I can edit an item by filling out a form" do
+    visit edit_merchant_item_path(@item)
+
+    expect(current_path).to eq("/dashboard/items/#{@item.id}/edit")
+
+    fill_in "item[name]", with: "Big Couch"
+    fill_in "item[description]", with: "It's a very large couch"
+    fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
+    fill_in "item[price]", with: "50.00"
+    fill_in "item[inventory]", with: "75"
+
+    click_on "Create Item"
+
+    expect(current_path).to eq(merchant_items_path)
+
+    new_item = Item.last
+
+    expect(page).to have_content("#{new_item.name} has been added")
+
+    within("#item-#{new_item.id}") do
+      expect(page).to have_link(new_item.name)
+      expect(page).to have_content("ID: #{new_item.id}")
+      expect(page).to have_css("img[src*='#{new_item.image}']")
+      expect(page).to have_content(number_to_currency(new_item.price))
+      expect(page).to have_content("#{new_item.inventory} in stock")
+      expect(page).to have_button("Disable Item")
+    end
+  end
+end

--- a/spec/features/merchant/items/edit_spec.rb
+++ b/spec/features/merchant/items/edit_spec.rb
@@ -30,34 +30,208 @@ RSpec.describe "Merchant Edits an Item", type: :feature do
 
       expect(current_path).to eq(edit_merchant_item_path(@item))
     end
-  end
 
-  xit "I can edit an item by filling out a form" do
-    visit edit_merchant_item_path(@item)
+    it "I can edit an item's name by filling out a form" do
+      visit edit_merchant_item_path(@item)
 
-    expect(current_path).to eq("/dashboard/items/#{@item.id}/edit")
+      expect(current_path).to eq("/dashboard/items/#{@item.id}/edit")
 
-    fill_in "item[name]", with: "Big Couch"
-    fill_in "item[description]", with: "It's a very large couch"
-    fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
-    fill_in "item[price]", with: "50.00"
-    fill_in "item[inventory]", with: "75"
+      new_name = "Big Couch"
 
-    click_on "Create Item"
+      fill_in "item[name]", with: new_name
+      # fill_in "item[description]", with: "It's a very large couch"
+      # fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
+      # fill_in "item[price]", with: "50.00"
+      # fill_in "item[inventory]", with: "75"
 
-    expect(current_path).to eq(merchant_items_path)
+      click_on "Update Item"
 
-    new_item = Item.last
+      expect(current_path).to eq(merchant_items_path)
 
-    expect(page).to have_content("#{new_item.name} has been added")
+      expect(page).to have_content("#{new_name} has been updated")
+      expect(@item.reload.name).to eq(new_item)
 
-    within("#item-#{new_item.id}") do
-      expect(page).to have_link(new_item.name)
-      expect(page).to have_content("ID: #{new_item.id}")
-      expect(page).to have_css("img[src*='#{new_item.image}']")
-      expect(page).to have_content(number_to_currency(new_item.price))
-      expect(page).to have_content("#{new_item.inventory} in stock")
-      expect(page).to have_button("Disable Item")
+      within("#item-#{@item.id}") do
+        expect(page).to have_link(new_name)
+        expect(page).to have_content("ID: #{@item.id}")
+        expect(page).to have_css("img[src*='#{@item.image}']")
+        expect(page).to have_content(number_to_currency(@item.price))
+        expect(page).to have_content("#{@item.inventory} in stock")
+      end
+    end
+
+    xit "more tests for editing other fields"
+
+    xit "I cannot leave the name field blank" do
+      visit new_merchant_item_path
+
+      # DON'T fill_in "item[name]"
+      fill_in "item[description]", with: "It's a very large couch"
+      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
+      fill_in "item[price]", with: "50.00"
+      fill_in "item[inventory]", with: "75"
+
+      click_on "Create Item"
+
+      expect(page).to have_field "item[description]"
+      expect(page).to have_content("Name can't be blank")
+      expect(Item.count).to eq(0)
+    end
+
+    xit "I cannot leave the description field blank" do
+      visit new_merchant_item_path
+
+      fill_in "item[name]", with: "Big Couch"
+      # DON'T fill_in "item[description]"
+      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
+      fill_in "item[price]", with: "50.00"
+      fill_in "item[inventory]", with: "75"
+
+      click_on "Create Item"
+
+      expect(page).to have_field "item[description]"
+      expect(page).to have_content("Description can't be blank")
+      expect(Item.count).to eq(0)
+
+    end
+
+    xit "I cannot leave the price field blank" do
+      visit new_merchant_item_path
+
+      fill_in "item[name]", with: "Big Couch"
+      fill_in "item[description]", with: "It's a very large couch"
+      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
+      # DON'T fill_in "item[price]"
+      fill_in "item[inventory]", with: "75"
+
+      click_on "Create Item"
+
+      expect(page).to have_field "item[description]"
+      expect(page).to have_content("Price can't be blank")
+      expect(Item.count).to eq(0)
+    end
+
+    xit "I cannot leave the inventory field blank" do
+      visit new_merchant_item_path
+
+      fill_in "item[name]", with: "Big Couch"
+      fill_in "item[description]", with: "It's a very large couch"
+      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
+      fill_in "item[price]", with: "50.00"
+      # DON'T fill_in "item[inventory]"
+
+      click_on "Create Item"
+
+      expect(page).to have_field "item[description]"
+      expect(page).to have_content("Inventory can't be blank")
+      expect(Item.count).to eq(0)
+    end
+
+    xit "I can leave thumbnail URL blank" do
+      visit new_merchant_item_path
+
+      expect(current_path).to eq('/dashboard/items/new')
+
+      fill_in "item[name]", with: "Big Couch"
+      fill_in "item[description]", with: "It's a very large couch"
+      # DON'T fill_in "item[image]"
+      fill_in "item[price]", with: "50.00"
+      fill_in "item[inventory]", with: "75"
+
+      click_on "Create Item"
+
+      expect(current_path).to eq(merchant_items_path)
+
+      new_item = Item.last
+
+      expect(page).to have_content("#{new_item.name} has been added")
+
+      within("#item-#{new_item.id}") do
+        expect(page).to have_link(new_item.name)
+        expect(page).to have_content("ID: #{new_item.id}")
+        expect(page).to have_css("img[src*='#{Item::DEFAULT_IMAGE}']")
+        expect(page).to have_content(number_to_currency(new_item.price))
+        expect(page).to have_content("#{new_item.inventory} in stock")
+        expect(page).to have_button("Disable Item")
+      end
+    end
+
+    xit "Price must be > 0.00" do
+      visit new_merchant_item_path
+
+      expect(current_path).to eq('/dashboard/items/new')
+
+      fill_in "item[name]", with: "Big Couch"
+      fill_in "item[description]", with: "It's a very large couch"
+      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
+      fill_in "item[price]", with: "-5.0"
+      fill_in "item[inventory]", with: "75"
+
+      click_on "Create Item"
+
+      expect(page).to have_field "item[description]"
+      expect(page).to have_content("Price must be greater than or equal to 0.01")
+      expect(Item.count).to eq(0)
+
+      fill_in "item[name]", with: "Big Couch"
+      fill_in "item[description]", with: "It's a very large couch"
+      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
+      fill_in "item[price]", with: "0.00"
+      fill_in "item[inventory]", with: "75"
+
+      click_on "Create Item"
+
+      expect(page).to have_field "item[description]"
+      expect(page).to have_content("Price must be greater than or equal to 0.01")
+      expect(Item.count).to eq(0)
+    end
+
+    xit "Inventory must be an integer >= 0" do
+      visit new_merchant_item_path
+
+      expect(current_path).to eq('/dashboard/items/new')
+
+      fill_in "item[name]", with: "Big Couch"
+      fill_in "item[description]", with: "It's a very large couch"
+      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
+      fill_in "item[price]", with: "5"
+      fill_in "item[inventory]", with: "-6"
+
+      click_on "Create Item"
+
+      expect(page).to have_field "item[description]"
+      expect(page).to have_content("Inventory must be greater than or equal to 0")
+      expect(Item.count).to eq(0)
+
+      fill_in "item[name]", with: "Big Couch"
+      fill_in "item[description]", with: "It's a very large couch"
+      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
+      fill_in "item[price]", with: "5.00"
+      fill_in "item[inventory]", with: "5.6"
+
+      click_on "Create Item"
+
+      expect(page).to have_field "item[description]"
+      expect(page).to have_content("Inventory must be an integer")
+      expect(Item.count).to eq(0)
+
+      fill_in "item[name]", with: "Big Couch"
+      fill_in "item[description]", with: "It's a very large couch"
+      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
+      fill_in "item[price]", with: "5.00"
+      fill_in "item[inventory]", with: "0"
+
+      click_on "Create Item"
+
+      expect(current_path).to eq(merchant_items_path)
+
+      new_item = Item.last
+
+      expect(page).to have_content("#{new_item.name} has been added")
+
+      within("#item-#{new_item.id}") do
+        expect(page).to have_link(new_item.name)
+      end
     end
   end
 end

--- a/spec/features/merchant/items/edit_spec.rb
+++ b/spec/features/merchant/items/edit_spec.rb
@@ -31,6 +31,31 @@ RSpec.describe "Merchant Edits an Item", type: :feature do
       expect(current_path).to eq(edit_merchant_item_path(@item))
     end
 
+    it "I cannot see the form to edit another merchant's item" do
+      other_merchant = create(:merchant)
+      other_item = create(:item, user: other_merchant)
+
+      visit edit_merchant_item_path(other_item)
+
+      expect(status_code).to eq(404)
+    end
+
+    it "I cannot edit another merchant's item" do
+      visit merchant_items_path
+
+      within("#item-#{@item.id}") do
+        click_button "Edit Item"
+      end
+
+      other_merchant = create(:merchant)
+
+      @item.update(user: other_merchant)
+
+      click_on "Update Item"
+
+      expect(status_code).to eq(404)
+    end
+
     it "I can edit an item's name by filling out a form" do
       visit edit_merchant_item_path(@item)
 
@@ -49,7 +74,7 @@ RSpec.describe "Merchant Edits an Item", type: :feature do
       expect(current_path).to eq(merchant_items_path)
 
       expect(page).to have_content("#{new_name} has been updated")
-      expect(@item.reload.name).to eq(new_item)
+      expect(@item.reload.name).to eq(new_name)
 
       within("#item-#{@item.id}") do
         expect(page).to have_link(new_name)

--- a/spec/features/merchant/items/edit_spec.rb
+++ b/spec/features/merchant/items/edit_spec.rb
@@ -1,7 +1,6 @@
 # When I submit the form
 # I am taken back to my items page
 # I see the item's new information on the page, and it maintains its previous enabled/disabled state
-# If I left the image field blank, I see a placeholder image for the thumbnail
 
 require 'rails_helper'
 
@@ -10,6 +9,7 @@ RSpec.describe "Merchant Edits an Item", type: :feature do
     before(:each) do
       @merchant = create(:merchant)
       @item = create(:item, user: @merchant)
+      @inactive_item = create(:inactive_item, user: @merchant)
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
     end
@@ -64,6 +64,7 @@ RSpec.describe "Merchant Edits an Item", type: :feature do
 
       expect(page).to have_content("#{new_name} has been updated")
       expect(@item.reload.name).to eq(new_name)
+      expect(@item.active).to eq(true)
 
       within("#item-#{@item.id}") do
         expect(page).to have_link(new_name)
@@ -75,9 +76,9 @@ RSpec.describe "Merchant Edits an Item", type: :feature do
     end
 
     it "I can edit an item's description by filling out a form" do
-      visit edit_merchant_item_path(@item)
+      visit edit_merchant_item_path(@inactive_item)
 
-      expect(current_path).to eq("/dashboard/items/#{@item.id}/edit")
+      expect(current_path).to eq("/dashboard/items/#{@inactive_item.id}/edit")
 
       new_description = "It's a very large couch"
 
@@ -87,8 +88,9 @@ RSpec.describe "Merchant Edits an Item", type: :feature do
 
       expect(current_path).to eq(merchant_items_path)
 
-      expect(page).to have_content("#{@item.reload.name} has been updated")
-      expect(@item.reload.description).to eq(new_description)
+      expect(page).to have_content("#{@inactive_item.reload.name} has been updated")
+      expect(@inactive_item.reload.description).to eq(new_description)
+      expect(@inactive_item.active).to eq(false)
     end
 
     it "I can edit an item's image by filling out a form" do

--- a/spec/features/merchant/items/edit_spec.rb
+++ b/spec/features/merchant/items/edit_spec.rb
@@ -64,10 +64,6 @@ RSpec.describe "Merchant Edits an Item", type: :feature do
       new_name = "Big Couch"
 
       fill_in "item[name]", with: new_name
-      # fill_in "item[description]", with: "It's a very large couch"
-      # fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
-      # fill_in "item[price]", with: "50.00"
-      # fill_in "item[inventory]", with: "75"
 
       click_on "Update Item"
 
@@ -85,7 +81,85 @@ RSpec.describe "Merchant Edits an Item", type: :feature do
       end
     end
 
-    xit "more tests for editing other fields"
+    it "I can edit an item's description by filling out a form" do
+      visit edit_merchant_item_path(@item)
+
+      expect(current_path).to eq("/dashboard/items/#{@item.id}/edit")
+
+      new_description = "It's a very large couch"
+
+      fill_in "item[description]", with: new_description
+
+      click_on "Update Item"
+
+      expect(current_path).to eq(merchant_items_path)
+
+      expect(page).to have_content("#{@item.reload.name} has been updated")
+      expect(@item.reload.description).to eq(new_description)
+    end
+
+    it "I can edit an item's image by filling out a form" do
+      visit edit_merchant_item_path(@item)
+
+      expect(current_path).to eq("/dashboard/items/#{@item.id}/edit")
+
+      new_image = "https://slimages.macysassets.com/is/image/MCY/products/0/optimized/8235120_fpx.tif?op_sharpen=1&wid=500&hei=613&fit=fit,1&$filtersm$"
+
+      fill_in "item[image]", with: new_image
+
+      click_on "Update Item"
+
+      expect(current_path).to eq(merchant_items_path)
+
+      expect(page).to have_content("#{@item.reload.name} has been updated")
+      expect(@item.reload.image).to eq(new_image)
+
+      within("#item-#{@item.id}") do
+        expect(page).to have_css("img[src*='#{new_image}']")
+      end
+    end
+
+    it "I can edit an item's price by filling out a form" do
+      visit edit_merchant_item_path(@item)
+
+      expect(current_path).to eq("/dashboard/items/#{@item.id}/edit")
+
+      new_price = "3.23"
+
+      fill_in "item[price]", with: new_price
+
+      click_on "Update Item"
+
+      expect(current_path).to eq(merchant_items_path)
+
+      expect(page).to have_content("#{@item.reload.name} has been updated")
+      expect(@item.reload.price.to_f).to eq(new_price.to_f)
+
+      within("#item-#{@item.id}") do
+        expect(page).to have_content(number_to_currency(new_price))
+      end
+    end
+
+    it "I can edit an item's inventory by filling out a form" do
+      visit edit_merchant_item_path(@item)
+
+      expect(current_path).to eq("/dashboard/items/#{@item.id}/edit")
+
+      new_inventory = 42
+
+      fill_in "item[inventory]", with: new_inventory
+
+      click_on "Update Item"
+
+      expect(current_path).to eq(merchant_items_path)
+
+      expect(page).to have_content("#{@item.reload.name} has been updated")
+      expect(@item.reload.inventory).to eq(new_inventory)
+
+      within("#item-#{@item.id}") do
+        expect(page).to have_content("#{new_inventory} in stock")
+      end
+    end
 
     xit "I cannot leave the name field blank" do
       visit new_merchant_item_path

--- a/spec/features/merchant/items/edit_spec.rb
+++ b/spec/features/merchant/items/edit_spec.rb
@@ -1,12 +1,5 @@
-# The form is re-populated with all of this item's information
-# I can change any information, but all of the rules for adding a new item still apply:
-# - name and description cannot be blank
-# - price cannot be less than $0.00
-# - inventory must be 0 or greater
-#
 # When I submit the form
 # I am taken back to my items page
-# I see a flash message indicating my item is updated
 # I see the item's new information on the page, and it maintains its previous enabled/disabled state
 # If I left the image field blank, I see a placeholder image for the thumbnail
 
@@ -161,176 +154,93 @@ RSpec.describe "Merchant Edits an Item", type: :feature do
       end
     end
 
-    xit "I cannot leave the name field blank" do
-      visit new_merchant_item_path
+    it "I cannot leave the name field blank" do
+      visit edit_merchant_item_path(@item)
 
-      # DON'T fill_in "item[name]"
-      fill_in "item[description]", with: "It's a very large couch"
-      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
-      fill_in "item[price]", with: "50.00"
-      fill_in "item[inventory]", with: "75"
-
-      click_on "Create Item"
+      fill_in "item[name]", with: ""
+      click_on "Update Item"
 
       expect(page).to have_field "item[description]"
       expect(page).to have_content("Name can't be blank")
-      expect(Item.count).to eq(0)
     end
 
     xit "I cannot leave the description field blank" do
-      visit new_merchant_item_path
+      visit edit_merchant_item_path(@item)
 
-      fill_in "item[name]", with: "Big Couch"
-      # DON'T fill_in "item[description]"
-      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
-      fill_in "item[price]", with: "50.00"
-      fill_in "item[inventory]", with: "75"
-
-      click_on "Create Item"
+      fill_in "item[description]", with: ""
+      click_on "Update Item"
 
       expect(page).to have_field "item[description]"
       expect(page).to have_content("Description can't be blank")
-      expect(Item.count).to eq(0)
-
     end
 
     xit "I cannot leave the price field blank" do
-      visit new_merchant_item_path
+      visit edit_merchant_item_path(@item)
 
-      fill_in "item[name]", with: "Big Couch"
-      fill_in "item[description]", with: "It's a very large couch"
-      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
-      # DON'T fill_in "item[price]"
-      fill_in "item[inventory]", with: "75"
-
-      click_on "Create Item"
+      fill_in "item[price]", with: ""
+      click_on "Update Item"
 
       expect(page).to have_field "item[description]"
       expect(page).to have_content("Price can't be blank")
-      expect(Item.count).to eq(0)
     end
 
     xit "I cannot leave the inventory field blank" do
-      visit new_merchant_item_path
+      visit edit_merchant_item_path(@item)
 
-      fill_in "item[name]", with: "Big Couch"
-      fill_in "item[description]", with: "It's a very large couch"
-      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
-      fill_in "item[price]", with: "50.00"
-      # DON'T fill_in "item[inventory]"
-
-      click_on "Create Item"
+      fill_in "item[inventory]", with: ""
+      click_on "Update Item"
 
       expect(page).to have_field "item[description]"
       expect(page).to have_content("Inventory can't be blank")
-      expect(Item.count).to eq(0)
     end
 
     xit "I can leave thumbnail URL blank" do
-      visit new_merchant_item_path
+      visit edit_merchant_item_path(@item)
 
       expect(current_path).to eq('/dashboard/items/new')
 
-      fill_in "item[name]", with: "Big Couch"
-      fill_in "item[description]", with: "It's a very large couch"
-      # DON'T fill_in "item[image]"
-      fill_in "item[price]", with: "50.00"
-      fill_in "item[inventory]", with: "75"
-
-      click_on "Create Item"
+      fill_in "item[image]", with: ""
+      click_on "Update Item"
 
       expect(current_path).to eq(merchant_items_path)
 
-      new_item = Item.last
+      expect(page).to have_content("#{@item.name} has been updated")
 
-      expect(page).to have_content("#{new_item.name} has been added")
-
-      within("#item-#{new_item.id}") do
-        expect(page).to have_link(new_item.name)
-        expect(page).to have_content("ID: #{new_item.id}")
+      within("#item-#{@item.id}") do
         expect(page).to have_css("img[src*='#{Item::DEFAULT_IMAGE}']")
-        expect(page).to have_content(number_to_currency(new_item.price))
-        expect(page).to have_content("#{new_item.inventory} in stock")
-        expect(page).to have_button("Disable Item")
       end
     end
 
     xit "Price must be > 0.00" do
-      visit new_merchant_item_path
+      visit edit_merchant_item_path(@item)
 
-      expect(current_path).to eq('/dashboard/items/new')
-
-      fill_in "item[name]", with: "Big Couch"
-      fill_in "item[description]", with: "It's a very large couch"
-      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
       fill_in "item[price]", with: "-5.0"
-      fill_in "item[inventory]", with: "75"
-
-      click_on "Create Item"
+      click_on "Update Item"
 
       expect(page).to have_field "item[description]"
       expect(page).to have_content("Price must be greater than or equal to 0.01")
-      expect(Item.count).to eq(0)
 
-      fill_in "item[name]", with: "Big Couch"
-      fill_in "item[description]", with: "It's a very large couch"
-      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
       fill_in "item[price]", with: "0.00"
-      fill_in "item[inventory]", with: "75"
-
-      click_on "Create Item"
+      click_on "Update Item"
 
       expect(page).to have_field "item[description]"
       expect(page).to have_content("Price must be greater than or equal to 0.01")
-      expect(Item.count).to eq(0)
     end
 
-    xit "Inventory must be an integer >= 0" do
-      visit new_merchant_item_path
+    it "Inventory must be an integer >= 0" do
+      visit edit_merchant_item_path(@item)
 
-      expect(current_path).to eq('/dashboard/items/new')
-
-      fill_in "item[name]", with: "Big Couch"
-      fill_in "item[description]", with: "It's a very large couch"
-      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
-      fill_in "item[price]", with: "5"
       fill_in "item[inventory]", with: "-6"
-
-      click_on "Create Item"
+      click_on "Update Item"
 
       expect(page).to have_field "item[description]"
       expect(page).to have_content("Inventory must be greater than or equal to 0")
-      expect(Item.count).to eq(0)
 
-      fill_in "item[name]", with: "Big Couch"
-      fill_in "item[description]", with: "It's a very large couch"
-      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
-      fill_in "item[price]", with: "5.00"
       fill_in "item[inventory]", with: "5.6"
-
-      click_on "Create Item"
+      click_on "Update Item"
 
       expect(page).to have_field "item[description]"
       expect(page).to have_content("Inventory must be an integer")
-      expect(Item.count).to eq(0)
-
-      fill_in "item[name]", with: "Big Couch"
-      fill_in "item[description]", with: "It's a very large couch"
-      fill_in "item[image]", with: "https://cdn.sofadreams.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/m/e/megasofa_leder_wohnlandschaft_big_couch_concept_beleuchtung_schwarz_1_1.jpg"
-      fill_in "item[price]", with: "5.00"
-      fill_in "item[inventory]", with: "0"
-
-      click_on "Create Item"
-
-      expect(current_path).to eq(merchant_items_path)
-
-      new_item = Item.last
-
-      expect(page).to have_content("#{new_item.name} has been added")
-
-      within("#item-#{new_item.id}") do
-        expect(page).to have_link(new_item.name)
-      end
     end
   end
 end


### PR DESCRIPTION
Closes User Stories 50 (#33) & 51 (#32): Merchant Edits an Item (& validations thereof)

Feature tests(%) - 100
Model tests(%) - 100

**Story 50:**
As a merchant
When I visit my items page
And I click the edit button or link next to any item
Then I am taken to a form similar to the 'new item' form
My URI route will be "/dashboard/items/15/edit" (if the item's ID was 15)
The form is re-populated with all of this item's information
I can change any information, but all of the rules for adding a new item still apply:
- name and description cannot be blank
- price cannot be less than $0.00
- inventory must be 0 or greater

When I submit the form
I am taken back to my items page
I see a flash message indicating my item is updated
I see the item's new information on the page, and it maintains its previous enabled/disabled state
If I left the image field blank, I see a placeholder image for the thumbnail

**Story 51:**
As a merchant
When I try to edit an existing item
If any of my data is incorrect or missing (except image)
Then I am returned to the form
I see one or more flash messages indicating each error I caused
All fields are re-populated with my previous data